### PR TITLE
chore: Remove settings.yml in favour of hs-github-tools.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,8 +1,0 @@
----
-repository:
-  name: toktok-fuzzer
-  description: TokTok fuzzing corpus and coverage results.
-  topics: fuzzing, tox
-
-branches:
-  - name: "master"


### PR DESCRIPTION
Centralised settings means we can update them without having to pass all the CI checks of each repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toktok-fuzzer/21)
<!-- Reviewable:end -->
